### PR TITLE
Update Factory.php

### DIFF
--- a/src/Common/Factory.php
+++ b/src/Common/Factory.php
@@ -143,7 +143,7 @@ class Factory
             $this->dom->addChild(
                 $this->rps,
                 "nfe:VlIss",
-                '0',
+                '0,00',
                 true
             );
             $this->dom->addChild(
@@ -163,7 +163,7 @@ class Factory
             $this->dom->addChild(
                 $this->rps,
                 "nfe:VlIssRet",
-                '0',
+                '0,00',
                 true
             );
         }


### PR DESCRIPTION
Correção do formato dos campos VlIss e VlIssRet qd forçados = 0 baseado no valor do campo retfonte.

Eles devem ser "0,00" e não apenas "0". Isso estava causando erro pra mim com refonte = NAO. Após a alteração o layout foi validado.